### PR TITLE
Query releases with productID during upload command

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -266,7 +266,6 @@ func uploadRun(cmd *cobra.Command, args []string) error {
 	release := &keygenext.Release{
 		ID:        uploadOpts.Release,
 		PackageID: &uploadOpts.Package,
-		ProductID: keygenext.Product,
 	}
 
 	// get actual release id w/ filters e.g. package

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -266,6 +266,7 @@ func uploadRun(cmd *cobra.Command, args []string) error {
 	release := &keygenext.Release{
 		ID:        uploadOpts.Release,
 		PackageID: &uploadOpts.Package,
+		ProductID: keygenext.Product,
 	}
 
 	// get actual release id w/ filters e.g. package

--- a/internal/keygenext/release.go
+++ b/internal/keygenext/release.go
@@ -123,7 +123,7 @@ func (r *Release) Get() error {
 		Product string `url:"product,omitempty"`
 	}
 
-	qs := querystring{Package: *r.PackageID, Product: r.ProductID}
+	qs := querystring{Package: *r.PackageID, Product: Product}
 	values, err := query.Values(qs)
 	if err != nil {
 		return err

--- a/internal/keygenext/release.go
+++ b/internal/keygenext/release.go
@@ -120,9 +120,10 @@ func (r *Release) Get() error {
 	// TODO(ezekg) Add support for custom query params to SDK
 	type querystring struct {
 		Package string `url:"package,omitempty"`
+		Product string `url:"product,omitempty"`
 	}
 
-	qs := querystring{Package: *r.PackageID}
+	qs := querystring{Package: *r.PackageID, Product: r.ProductID}
 	values, err := query.Values(qs)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add the product ID to the upload function's call to Release.Get in order to return the correct release in the event the user is using an Admin token which can see releases for multiple products.